### PR TITLE
fix: incorrect static path

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const uuid = require('uuid');
 app.disable('x-powered-by')
 
 //middlewares
-app.use(express.static('public'));
+app.use(express.static('client'));
 
 //routes
 app.get('/', (req,res)=>{


### PR DESCRIPTION
the path for the static middleware was set to ``public``, but the folder is named ``client``